### PR TITLE
Add copyright and github information

### DIFF
--- a/src/zepto.fullpage.js
+++ b/src/zepto.fullpage.js
@@ -1,3 +1,11 @@
+/*!
+ * zepto.fullpage.js
+ * https://github.com/yanhaijing/zepto.fullpage
+ * MIT licensed
+ * API https://github.com/yanhaijing/zepto.fullpage/blob/master/doc/api.md
+ *
+ * Copyright (C) 2015 Yanhaijing, http://yanhaijing.com
+ */
 (function($, window, undefined) {
     if (typeof $ === 'undefined') {
         throw new Error('zepto.fullpage\'s script requires Zepto');
@@ -192,7 +200,7 @@
         }
         return this;
     };
-    //暴漏方法
+    //暴露方法
     $.each(['update', 'moveTo', 'moveNext', 'movePrev', 'start', 'stop'], function(key, val) {
         $.fn.fullpage[val] = function() {
             if (!fullpage) {


### PR DESCRIPTION
Add copyright and github information on the top, so that users can find
the entrance to the source project and are easier to reach the API
document.

btw fix a typo：暴漏 -> 暴露

Thanks for the plugin, it is really good.
