### PR TITLE
修复document的touchmove事件默认passive:true导致下拉刷新等bug

### DIFF
--- a/src/js.fullpage.js
+++ b/src/js.fullpage.js
@@ -19,6 +19,20 @@
         orientationchange: function(orientation) {}
     };
 
+    var passiveSupported = false;
+
+    try {
+      var options = Object.defineProperty({}, "passive", {
+        get: function() {
+          passiveSupported = true;
+        }
+      });
+
+      window.addEventListener("test", null, options);
+    } catch(err) {}
+
+    const passiveListener = passiveSupported ? { passive: false, capture: false } : false
+
     function touchmove(e) {
         e.preventDefault();
     }
@@ -163,10 +177,10 @@
         }, false);
     };
     Fullpage.prototype.holdTouch = function() {
-        document.addEventListener('touchmove', touchmove);
+        document.addEventListener('touchmove', touchmove, passiveListener);
     };
     Fullpage.prototype.unholdTouch = function() {
-        document.removeEventListener('touchmove', touchmove);
+        document.removeEventListener('touchmove', touchmove, passiveListener);
     };
     Fullpage.prototype.start = function() {
         this.status = 1;


### PR DESCRIPTION
Chrome 56以上开始设置默认设置document touchmove listeners的passive:true提高滚动性能, 这样导致设置的e.preventDefault()无效. 不能阻止下拉刷新,IPhoneX上滑也有问题.